### PR TITLE
Add venv to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 **/*.py
 build
+venv


### PR DESCRIPTION
## Summary
Added venv directory to .gitignore to support local virtual environment setup for Python dependencies.

## Test plan
- Create venv: `python3 -m venv venv`
- Install dependencies: `venv/bin/pip install marko==2.0.0`
- Activate and build: `. venv/bin/activate && tome build`
- Verify venv directory is ignored by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)